### PR TITLE
Allow OPTIONS requests without user credentials

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,7 @@ module.exports = function basicAuth(callback, realm) {
   return function(req, res, next) {
     var authorization = req.headers.authorization;
 
+    if (req.method == 'OPTIONS') return next();
     if (req.user) return next();
     if (!authorization) return unauthorized(res, realm);
 


### PR DESCRIPTION
Per [https://www.w3.org/TR/cors/#preflight-request](https://www.w3.org/TR/cors/#preflight-request), OPTIONS (CORS preflight) requests should "exclude user credentials".

This commit ensures that basic-auth-connect ignores authentication server-side when there is an OPTIONS request.
